### PR TITLE
Improve install error message when --dest is missing

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -121,7 +121,11 @@ async function run() {
 
     const options = parseOptions(argv.slice(2));
     if (!options.dest) {
-      throw new Error("Destination path is required. Use --dest <path>.");
+      throw new Error(
+        "Missing required option --dest.\n\n" +
+          "Example:\n" +
+          "  brainkit install threejs-performance-optimizer --dest ./my-skills",
+      );
     }
 
     if (!["artifact", "source"].includes(options.mode)) {


### PR DESCRIPTION
This PR improves the error shown when running `brainkit install` without the required --dest option.

Changes:
- Enhanced the error message to include a complete example command.
- Behavior remains unchanged when --dest is provided.

Tested locally:
- `node dist/cli.js install threejs-performance-optimizer` shows the improved error message.
- `node dist/cli.js install threejs-performance-optimizer --dest ./test-skills` works as before.

Closes #7