### PR TITLE
Add CLI version command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   getManifest,
   getSkillArtifactPath,
@@ -9,6 +12,13 @@ import {
   installSkill,
   listSkills,
 } from "./index.js";
+
+const packageJson = JSON.parse(
+  readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "..", "package.json"),
+    "utf8",
+  ),
+);
 
 function parseOptions(argv) {
   const options = {
@@ -47,6 +57,7 @@ Usage:
   brainkit list
   brainkit catalog
   brainkit manifest
+  brainkit version
   brainkit where <skill> [--mode artifact|source]
   brainkit install <skill|all> --dest <path> [--mode artifact|source]
 
@@ -69,6 +80,11 @@ async function run() {
     command === "-h"
   ) {
     printHelp();
+    return;
+  }
+
+  if (command === "version" || command === "--version" || command === "-v") {
+    console.log(packageJson.version);
     return;
   }
 

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -4,6 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json");
 
 const cliPath = path.resolve("dist/cli.js");
 const knownSkill = "threejs-performance-optimizer";
@@ -24,6 +28,23 @@ test("cli prints help when no command is provided", () => {
   assert.equal(result.status, 0);
   assert.match(result.stdout, /brainkit CLI/);
   assert.match(result.stdout, /Usage:/);
+  assert.match(result.stdout, /brainkit version/);
+});
+
+test("cli version command prints package version", () => {
+  const result = runCli(["version"]);
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout.trim(), packageJson.version);
+  assert.equal(result.stderr, "");
+});
+
+test("cli version flag prints package version", () => {
+  const result = runCli(["--version"]);
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout.trim(), packageJson.version);
+  assert.equal(result.stderr, "");
 });
 
 test("cli list prints bundled skills", () => {


### PR DESCRIPTION
## Summary

Fixes #5.

This adds package-version output to the CLI:

- `brainkit version`
- `brainkit --version`
- `brainkit -v`

The help text now includes `brainkit version`, and the output is a clean single-line version string sourced from `package.json`.

## Verification

```sh
npm test
npm pack --pack-destination /tmp/earn-micro-scan/brainkit-pack
```

Fresh install smoke from the packed tarball:

```sh
npm install --ignore-scripts --no-audit --no-fund /tmp/earn-micro-scan/brainkit-pack/alaagh-brainkit-2.0.2.tgz
./node_modules/.bin/brainkit version
./node_modules/.bin/brainkit --version
./node_modules/.bin/brainkit --help | rg 'brainkit version'
```

Observed:

```text
2.0.2
2.0.2
  brainkit version
```
