### PR TITLE
feat: add version command and flags

### DIFF
--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -77,7 +77,7 @@ for (const slug of skillSlugs) {
   }
 
   const content = readFileSync(skillFile, "utf8");
-  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n/);
+  const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
 
   if (!frontmatterMatch) {
     throw new Error(`Missing YAML frontmatter in ${skillFile}`);

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+
 import {
   getManifest,
   getSkillArtifactPath,
@@ -9,6 +13,14 @@ import {
   installSkill,
   listSkills,
 } from "./index.js";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+function getVersion() {
+  const packageJsonPath = join(__dirname, "..", "package.json");
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  return packageJson.version;
+}
 
 function parseOptions(argv) {
   const options = {
@@ -47,12 +59,14 @@ Usage:
   brainkit list
   brainkit catalog
   brainkit manifest
+  brainkit version
   brainkit where <skill> [--mode artifact|source]
   brainkit install <skill|all> --dest <path> [--mode artifact|source]
 
 Examples:
   brainkit list
   brainkit catalog
+  brainkit version
   brainkit install threejs-performance-optimizer --dest ~/.config/opencode/skills
   brainkit install all --mode source --dest ./local-skills
 `);
@@ -69,6 +83,15 @@ async function run() {
     command === "-h"
   ) {
     printHelp();
+    return;
+  }
+
+  if (
+    command === "version" ||
+    command === "--version" ||
+    command === "-v"
+  ) {
+    console.log(getVersion());
     return;
   }
 

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -24,6 +24,24 @@ test("cli prints help when no command is provided", () => {
   assert.equal(result.status, 0);
   assert.match(result.stdout, /brainkit CLI/);
   assert.match(result.stdout, /Usage:/);
+  assert.match(result.stdout, /brainkit version/);
+});
+
+test("cli version prints current package version", () => {
+  const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+  const expectedVersion = packageJson.version;
+
+  const result1 = runCli(["version"]);
+  assert.equal(result1.status, 0);
+  assert.equal(result1.stdout.trim(), expectedVersion);
+
+  const result2 = runCli(["--version"]);
+  assert.equal(result2.status, 0);
+  assert.equal(result2.stdout.trim(), expectedVersion);
+
+  const result3 = runCli(["-v"]);
+  assert.equal(result3.status, 0);
+  assert.equal(result3.stdout.trim(), expectedVersion);
 });
 
 test("cli list prints bundled skills", () => {


### PR DESCRIPTION
This PR implements the missing version command and flags as requested in the microbounty. It includes implementation in src/cli.js and new test cases in tests/cli.test.mjs.